### PR TITLE
add Franklin Ave Shuttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ After setting these to your preferences, build and run the containers on your Ra
 ```
 sudo docker compose up backend frontend # start the containers for the app (not tests)
 ```
+test

--- a/backend/metadata/constants.py
+++ b/backend/metadata/constants.py
@@ -27,6 +27,7 @@ ENDPOINT_ROUTE_DICT = {
         "5",
         "6",
         "7",
+        "S"
     ],
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -133,9 +133,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/frontend/src/colors.ts
+++ b/frontend/src/colors.ts
@@ -15,7 +15,7 @@ const TrainColors: Record<Colors, string[]> = {
   [Colors.Orange]: ["B", "D", "F", "M"],
   [Colors.LightGreen]: ["G"],
   [Colors.Brown]: ["J", "Z"],
-  [Colors.Gray]: ["L"],
+  [Colors.Gray]: ["L", "S"],
   [Colors.Yellow]: ["N", "Q", "R", "W"],
   [Colors.Red]: ["1", "2", "3"],
   [Colors.DarkGreen]: ["4", "5", "6"],

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "outDir": "./dist",
         "rootDir": "./src",
-        "lib": ["ES2015", "DOM"]
+        "lib": ["ES2017", "DOM"]
     },
     "include": ["src/**/*"],
     "watchOptions": {


### PR DESCRIPTION
### Main Changes
- Include `S` as an option for routes in backend
- Add `S` to the gray color
- Minor ts config changes

### Future Considerations
The shuttle is a separate stop itself, so if a user wants to see a station that has both "normal" trains as well as a shuttle, they'll need to make multiple requests. 

Another thing to watch out for (and maybe will just ignore), the grand central shuttle uses a different endpoint than the franklin ave shuttle. This means for these stops, solely relying on `S` as the route name is insufficient. 